### PR TITLE
更新 Tura 产品描述

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 - [Choochmeque/tauri-plugin-notifications: 一个 Tauri v2 插件，用于在桌面和移动平台发送通知，支持系统通知以及通过 FCM 和 APNs 推送发送。](https://github.com/Choochmeque/tauri-plugin-notifications) 
 - [Licoy/StrokeMouse: macOS 鼠标手势自定义工具。按住该手势的触发键（默认右键，也可中键 / 侧键）绘制轨迹，匹配后执行快捷键、打开应用、窗口操作、媒体键、Shell / AppleScript 等](https://github.com/Licoy/StrokeMouse) 
 ### July 16, 2026
-- [Tura-AI/tura：本地开源 AI 编码代理，支持自定义模型提供商、CLI、TUI 和桌面界面，并公开长时程任务的逐轮工具调用、令牌用量、补丁及验证结果。](https://github.com/Tura-AI/tura)
+- [Tura-AI/tura：构建一个令牌使用量减少 80%、能交付更好结果的智能体。](https://github.com/Tura-AI/tura)
 
 ### July 10, 2026 
 - [kisielk/errcheck: errcheck 在 Go 代码中查找被悄悄忽略的错误。](https://github.com/kisielk/errcheck) 


### PR DESCRIPTION
说明

- 将现有 Tura 条目的中文描述更新为当前产品定位。
- 保留原日期、项目链接和列表结构。

关联披露

我与 Tura 项目有关联。